### PR TITLE
Add weight to hovertext

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ License: GPL (>= 2)
 URL: http://github.com/haleyjeppson/ggmosaic
 BugReports: https://github.com/haleyjeppson/ggmosaic
 LazyData: TRUE
-RoxygenNote: 5.0.1.9000
+RoxygenNote: 5.0.1
 Suggests:
     knitr,
     rmarkdown

--- a/R/geom2plotly.R
+++ b/R/geom2plotly.R
@@ -1,36 +1,8 @@
 #' @export
-to_basic.GeomMosaic <- function (data, prestats_data, layout, params, p, ...)
-{
-  data <- subset(data, level==max(level))
- # browser()
-  data$hovertext<- gsub("\n", "<br>", data$label)
-  data$hovertext<- gsub("-", ": ", data$hovertext)
-
-  # x.vars<- data[ , grepl("x[0-9]", colnames(data))]
-  # x.values <- data.frame(sapply(x.vars, function(x) gsub("-", ": ", x)))
-  # x.values[] <- lapply(x.values, as.character)
-  # labs <- tidyr::unite_(x.values, col="labs", from=colnames(x.values)[], sep=" <br>")
-  # fill.vars <- c(gsub(".*<", "<", data$hovertext))
-  # all <- data.frame(labs, fill.vars)
-  # data$hovertext <- unlist(c(tidyr::unite_(all, col="hovertxt", from=colnames(all)[], sep="")))
-
-  data$group <- seq_len(nrow(data))
-  others <- data[!names(data) %in% c("xmin", "ymin", "xmax",
-                                     "ymax")]
-  data <- with(data, {
-    rbind(cbind(x = xmin, y = ymin, others), cbind(x = xmin,
-                                                   y = ymax, others), cbind(x = xmax, y = ymax, others),
-          cbind(x = xmax, y = ymin, others))
-  })
-
-  prefix_class(data, "GeomPolygon")
+to_basic.GeomMosaic <- function (data, prestats_data, layout, params, p, ...) {
+  data <- subset(data, level == max(level))
+  data$hovertext <- gsub("\n", "<br>", data$label)
+  data$hovertext <- gsub("-", ": ", data$hovertext)
+  data$hovertext <- paste0(data$hovertext, "<br>Weight: ", data[[".wt"]])
+  to_basic.GeomRect(data)
 }
-
-
- # to_basic.GeomRect <- getFromNamespace("to_basic.GeomRect", asNamespace("plotly"))
-
-
-  prefix_class <- function(x, y) {
-    structure(x, class = unique(c(y, class(x))))
-  }
-


### PR DESCRIPTION
This essentially adds `.wt` to hovertext, but I wanted to also point out that this approach won't respect the `tooltip` argument in `ggplotly()` (meaning users won't be able to hide certain variables in the tooltip). If you want to support that, I recently attached `tooltip` to `p` so you can access it in the `to_basic` function with `p[["tooltip"]]`. If you're interested, and have any questions, I'd be happy to help.