### PR TITLE
Tag docs/ & visual_test/ as doc for GH linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/* linguist-documentation
+visual_test/* linguist-documentation


### PR DESCRIPTION
:wave: Hi @haleyjeppson 
I've noticed that `ggmosaic` is tagged as mostly HTML by [GitHub's linguist](https://github.com/github/linguist), I've followed the [overriding instructions](https://github.com/github/linguist#overrides) which should let the repo be tagged as pure R.