### PR TITLE
Change `ggplot2::is.waive` to `ggplot2::is.waiver`

### DIFF
--- a/R/scale-product.R
+++ b/R/scale-product.R
@@ -34,7 +34,7 @@ scale_x_productlist <- function(name = ggplot2::waiver(), breaks = product_break
   )
 
 
-  if (!is.waive(sec.axis)) {
+  if (!ggplot2::is.waiver(sec.axis)) {
     if (is.formula(sec.axis)) sec.axis <- ggplot2::sec_axis(sec.axis)
     is.sec_axis = getFromNamespace("is.sec_axis", "ggplot2")
     if (is.sec_axis(sec.axis)) stop("Secondary axes must be specified using 'sec_axis()'")
@@ -60,7 +60,7 @@ scale_y_productlist <- function(name = ggplot2::waiver(), breaks = product_break
     guide = ggplot2::waiver(), position = position, super = ScaleContinuousProduct
   )
 
-  if (!is.waive(sec.axis)) {
+  if (!ggplot2::is.waiver(sec.axis)) {
     if (is.formula(sec.axis)) sec.axis <- ggplot2::sec_axis(sec.axis)
     is.sec_axis = getFromNamespace("is.sec_axis", "ggplot2")
     if (is.sec_axis(sec.axis)) stop("Secondary axes must be specified using 'sec_axis()'")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -52,7 +52,6 @@ product_labels <- function() {
   }
 }
 
-is.waive <- getFromNamespace("is.waive", "ggplot2")
 
 
 


### PR DESCRIPTION
Development version of `ggplot2` no longer has a function called `is.waive`. It was renamed to `is.waiver` in this PR and is now exported https://github.com/tidyverse/ggplot2/pull/6173